### PR TITLE
Change the logic to retrieve the courseId from the url

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ var sboModule = sboModule || {};
     let startNew = function () {
 
         let techbusBaseUrl = 'https://techbus.safaribooksonline.com/';
-        let courseId = window.location.pathname.match('/([0-9]+)/?')[1];
+        let courseId = window.location.pathname.split('/')[3];
 
         $.get(techbusBaseUrl + courseId).always(function (html) {
             sboModule.crawlerService.crawl($('.tab-group-content ol > li').children('div.content-ContentSummary').parent(), html);


### PR DESCRIPTION
- It seems they introduced some letters in courseId
- It seems the courseId is always in the 4th position in the url
- Use split instead of match as we assume to always find the info on the 4th position
- This will cover more cases than current implementation (current logic is failing on cases like /videos/77-728-expert-excel/9781838641290 as it is catching the 3rd position)

This should improve the courseId coverage, at least for the cases below:
- /videos/77-728-expert-excel/9781838641290 (77 was the result of the current pattern and will now be 9781838641290)
- /videos/angular-8/9781788998437 (8 was the result of the current pattern and will now be 9781788998437)
- /videos/microsoft-az-103-azure/10009AZ100454545 (103 was the result of current pattern + it would never match the letters in the courseId)